### PR TITLE
Return lintr-style result from type checking

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,4 +21,6 @@ Imports:
     purrr,
     rlang,
     types,
-    magrittr
+    magrittr,
+    xmlparsedata,
+    xml2

--- a/R/interface.R
+++ b/R/interface.R
@@ -12,6 +12,19 @@ interpreter <- function() {
 }
 
 
+#' @param x An XML tree returned by `xml2::as_list(xml2::read_xml())`
+get_line_col <- function(x) {
+    if (!is.list(x[[1]])) {
+        return(list(
+            line_number = as.integer(attr(x, "line1")),
+            column_number = as.integer(attr(x, "col1"))
+        ))
+    } else {
+        return(Recall(x[[1]]))
+    }
+}
+
+
 #' Type check an R file
 #'
 #' @param path A character string; the file path.
@@ -22,24 +35,36 @@ interpreter <- function() {
 #' type_check(file)
 #'
 #' @export
-type_check <- function(path) {
-    es <- rlang::parse_exprs(file(path))
+type_check <- function(text) {
+    es <- parse(text = text, keep.source = TRUE)
+    tree <- xml2::as_list(xml2::read_xml(xmlparsedata::xml_parse_data(es)))[[1]]
     envir <- list()
     safe_eval_type <- purrr::safely(eval_type)
-    for (expr in es) {
+    errors <- list()
+    for (i_expr in seq_along(es)) {
+        expr <- es[[i_expr]]
         res <- safe_eval_type(expr, envir)
         if (!is.null(res$error)) {
+            line_col <- get_line_col(tree[[i_expr]])
             cat("In the expression:\n")
-            print(expr)
             cat("The following type error is found:\n")
             cat(res$error$message)
-            return(invisible(NULL))
+            errors <- c(errors, list(list(
+                filename = "<text>",
+                line_number = line_col$line_number,
+                column_number = line_col$column_number,
+                type = "type",
+                message = res$error$message,
+                line = expr,
+                ranges = NULL,
+                linter = "typeChecker"
+            )))
         } else {
             envir <- res$result$envir
         }
     }
     cat("The file is type-checked.")
-    invisible(NULL)
+    errors
 }
 
 push <- function(xs, el) {


### PR DESCRIPTION
Modifies `type_check()` to return a result in a similar form to that of `lintr::lint()`, so that type errors can be handled by editors in a similar way to lint warnings.

Also modifies the input of `type_check()` to be a string of code rather than a filename. It's useful to have a function that takes a string of code, so that it can be called by languageserver like `lintr::lint()`, but it could of course be called something other than `type_check`. Feel very free to make any changes you want.

I added the XML functions as a way of finding the corresponding line/column for the expression, but it's not accurate at the moment. I wonder if `xmlparsedata::xml_parse_data(es)` treats comments as expressions.