### PR TITLE
Show all errors with ranges

### DIFF
--- a/R/interface.R
+++ b/R/interface.R
@@ -49,13 +49,16 @@ type_check <- function(path) {
                 ranges = list(c(info$range$col1, info$range$col2)),
                 linter = "typeChecker"
             )))
-            return(invisible(errors))
         } else {
             envir <- res$result$envir
         }
     }
-    cat("The file is type-checked.")
-    return(invisible(NULL))
+    if (length(errors) > 0) {
+        return(invisible(errors))
+    } else {
+        cat("The file is type-checked.")
+        return(invisible(NULL))
+    }
 }
 
 push <- function(xs, el) {

--- a/R/interface.R
+++ b/R/interface.R
@@ -46,7 +46,7 @@ type_check <- function(path) {
                 type = "type",
                 message = info$error_msg,
                 line = info$expr,
-                ranges = c(info$range$line2, info$range$col2),
+                ranges = list(c(info$range$col1, info$range$col2)),
                 linter = "typeChecker"
             )))
             return(invisible(errors))

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -9,6 +9,8 @@ test_that("Test interface", {
 
     expected <- "Type mismatch error at 6:1-6:11
 In the expression: add('a', 3)
+Expected: numeric; Actual: character.Type mismatch error at 9:1-9:9
+In the expression: add(x, 3)
 Expected: numeric; Actual: character."
 
     testthat::expect_equal(output, expected)


### PR DESCRIPTION
This PR makes two changes to the results of `type_check`:

1. Returns all type errors, not just the first one
2. Changes format of `ranges` returned by `type_check` to match `ranges` returned by `lintr::lint` ([reference](https://github.com/jimhester/lintr/blob/3dbf24d5c7411471cd674e8db51a2b0b508b2aac/R/lint.R#L342))

Here's how it looks in VS Code:
![diagnostics-all](https://user-images.githubusercontent.com/23294156/105622596-1b1cc200-5e56-11eb-8aab-9816d110f774.png)
